### PR TITLE
Bug in CellList highlighting

### DIFF
--- a/src/main/java/com/googlecode/mgwt/ui/client/widget/CellList.java
+++ b/src/main/java/com/googlecode/mgwt/ui/client/widget/CellList.java
@@ -147,8 +147,10 @@ public class CellList<T> extends Composite implements HasCellSelectedHandler {
 
     @Override
     public void onTouchEnd(TouchEndEvent event) {
-      if (node != null)
+			if (node != null) {
         node.removeClassName(css.selected());
+				stopTimer();
+			}
       if (started && !moved && index != -1) {
         fireSelectionAtIndex(index, originalElement);
       }


### PR DESCRIPTION
There was a Bug within the highlighting of a CellList Entry. 

At a Galaxy-Tab 10.1N a selection Entry was not deselected by TouchEnd.

I added the "stopime()" from onTouchMove() to onTouchEnd().
