### PR TITLE
Fixed mistake in method remove of WidgetList

### DIFF
--- a/src/main/java/com/googlecode/mgwt/ui/client/widget/WidgetList.java
+++ b/src/main/java/com/googlecode/mgwt/ui/client/widget/WidgetList.java
@@ -210,7 +210,7 @@ public class WidgetList extends Composite implements HasWidgets {
       }
     }
     childCount--;
-    children.remove(w);
+    children.remove(entry);
     return container.remove(entry);
 
   }


### PR DESCRIPTION
The list 'children' contains WidgetListEntry so we have to remove 'entry' instead of 'w'. This caused that css styles were not updated correctly.
