### PR TITLE
Added vertical align property to swipe menu CSS

### DIFF
--- a/src/main/java/com/googlecode/mgwt/ui/client/widget/menu/swipe-menu.css
+++ b/src/main/java/com/googlecode/mgwt/ui/client/widget/menu/swipe-menu.css
@@ -19,6 +19,7 @@
 	width: 40%;
 	height: 100%;
 	overflow: hidden;
+	vertical-align: top;
 }
 
 .content {
@@ -27,6 +28,7 @@
 	width: 50%;
 	height: 100%;
 	overflow: hidden;
+	vertical-align: top;
 }
 
 @if user.agent safari {


### PR DESCRIPTION
Without "vertical-align: top" on the .menu and .content selectors, the two do not align properly.
