### PR TITLE
ProgressEvent data : loaded & total files in cache

### DIFF
--- a/src/main/java/com/googlecode/mgwt/linker/client/cache/event/ProgressEvent.java
+++ b/src/main/java/com/googlecode/mgwt/linker/client/cache/event/ProgressEvent.java
@@ -35,14 +35,35 @@ public class ProgressEvent extends GwtEvent<ProgressEvent.Handler> {
 		return TYPE;
 	}
 
+	private boolean lengthComputable;
+	private int loaded;
+	private int total;
+
+	public ProgressEvent(boolean lengthComputable, int loaded, int total) {
+		this.lengthComputable = lengthComputable;
+		this.loaded = loaded;
+		this.total = total;
+	}
+
 	@Override
 	public com.google.gwt.event.shared.GwtEvent.Type<Handler> getAssociatedType() {
 		return TYPE;
 	}
 
+	public boolean isLengthComputable() {
+		return lengthComputable;
+	}
+
+	public int getLoaded() {
+		return loaded;
+	}
+
+	public int getTotal() {
+		return total;
+	}
+
 	@Override
 	protected void dispatch(Handler handler) {
 		handler.onProgressEvent(this);
-
 	}
 }

--- a/src/main/java/com/googlecode/mgwt/linker/client/cache/html5/Html5ApplicationCache.java
+++ b/src/main/java/com/googlecode/mgwt/linker/client/cache/html5/Html5ApplicationCache.java
@@ -104,8 +104,8 @@ public class Html5ApplicationCache implements ApplicationCache {
     eventBus.fireEventFromSource(new DownloadingEvent(), this);
   }
 
-  protected void onProgress() {
-    eventBus.fireEventFromSource(new ProgressEvent(), this);
+  protected void onProgress(boolean lengthComputable, int loaded, int total) {
+    eventBus.fireEventFromSource(new ProgressEvent(lengthComputable, loaded, total), this);
   }
 
   protected void onUpdateReady() {
@@ -145,8 +145,8 @@ public class Html5ApplicationCache implements ApplicationCache {
 		});
 		$wnd.applicationCache.addEventListener("downloading", ondownloading);
 
-		var onprogress = $entry(function() {
-			that.@com.googlecode.mgwt.linker.client.cache.html5.Html5ApplicationCache::onProgress()();
+		var onprogress = $entry(function(event) {
+			that.@com.googlecode.mgwt.linker.client.cache.html5.Html5ApplicationCache::onProgress(ZII)(event.lengthComputable, event.loaded, event.total);
 		});
 		$wnd.applicationCache.addEventListener("progress", onprogress);
 


### PR DESCRIPTION
ProgressEvent is fully wrapped. Firefox does not provide all informations (lenthComputable is false in this case). Others browsers (at least Chrome & Safari) do.
