### PR TITLE
Bugfix MDateBox is not working on iOS7 Safari

### DIFF
--- a/src/main/java/com/googlecode/mgwt/ui/client/widget/MDateBox.java
+++ b/src/main/java/com/googlecode/mgwt/ui/client/widget/MDateBox.java
@@ -96,7 +96,12 @@ public class MDateBox extends MValueBoxBase<Date> {
 
     @Override
     public String render(Date object) {
-      return format.format(object);
+ 		if (object != null) {
+			return format.format(object);
+		}
+		else {
+			return "";
+		}
     }
 
     @Override


### PR DESCRIPTION
With this fix the MDateBox can be used in iOS7 Safari.
