### PR TITLE
Fixes ISSUE 307 Nav bar  showing on the nexus 7, 7 inch when the keyboard is shown

### DIFF
--- a/src/main/java/com/googlecode/mgwt/ui/UI.gwt.xml
+++ b/src/main/java/com/googlecode/mgwt/ui/UI.gwt.xml
@@ -199,5 +199,27 @@ under * the License.
 		<when-type-is class="com.googlecode.mgwt.ui.client.widget.menu.SwipeMenuAppearance" />
 	</replace-with>
 
+	<!-- Orientation handler -->
+    <replace-with class="com.googlecode.mgwt.ui.client.util.impl.IOSOrientationHandler">
+        <when-type-is class="com.googlecode.mgwt.ui.client.util.OrientationHandler" />
+    </replace-with>
+    
+    <!-- 
+    Uncomment this to use exactly the old implementation
+    <replace-with class="com.googlecode.mgwt.ui.client.util.impl.ResizeOrientationHandler">
+        <when-type-is class="com.googlecode.mgwt.ui.client.util.OrientationHandler" />
+    </replace-with>
+    
+    <replace-with class="com.googlecode.mgwt.ui.client.util.impl.IOSOrientationHandler">
+        <when-type-is class="com.googlecode.mgwt.ui.client.util.OrientationHandler" />
+            <any>
+                <when-property-is name="mgwt.os" value="iphone" />
+                <when-property-is name="mgwt.os" value="ipad"/>
+                <when-property-is name="mgwt.os" value="retina" />
+                <when-property-is name="mgwt.os" value="ipad_retina"/>
+            </any>
+    </replace-with> -->
+    
+	
 	<source path="client" />
 </module>

--- a/src/main/java/com/googlecode/mgwt/ui/client/MGWT.java
+++ b/src/main/java/com/googlecode/mgwt/ui/client/MGWT.java
@@ -38,13 +38,13 @@ import com.google.gwt.user.client.Timer;
 import com.google.gwt.user.client.Window;
 import com.google.gwt.user.client.ui.Anchor;
 import com.google.gwt.user.client.ui.RootPanel;
-
 import com.googlecode.mgwt.dom.client.event.orientation.OrientationChangeEvent;
 import com.googlecode.mgwt.dom.client.event.orientation.OrientationChangeEvent.ORIENTATION;
 import com.googlecode.mgwt.dom.client.event.orientation.OrientationChangeHandler;
 import com.googlecode.mgwt.ui.client.MGWTSettings.ViewPort;
 import com.googlecode.mgwt.ui.client.theme.base.UtilCss;
 import com.googlecode.mgwt.ui.client.util.AddressBarUtil;
+import com.googlecode.mgwt.ui.client.util.OrientationHandler;
 
 /**
  * The MGWT Object is used to apply settings for an MGWT App. It also provides an instance of
@@ -60,14 +60,25 @@ public class MGWT {
 
   private static EventBus manager;
 
-  private static ORIENTATION currentOrientation;
   private static Timer timer;
+
+  private static OrientationHandler orientationHandler;
 
   private static boolean scrollingDisabled;
   private static JavaScriptObject nativeJsFunction;
 
   private static AddressBarUtil addressBarUtil;
-
+  /**
+   * Return an orientation handler based on the current os.
+   * @return
+   */
+  public static OrientationHandler getOrientationHandler() {
+	  if ( orientationHandler == null){
+		  orientationHandler = GWT.create(OrientationHandler.class);
+		  
+	  }
+	return orientationHandler;
+}
   /**
    * Add a orientation handler to detect the device orientation
    * 
@@ -76,7 +87,7 @@ public class MGWT {
    * @return a {@link com.google.gwt.event.shared.HandlerRegistration} object.
    */
   public static HandlerRegistration addOrientationChangeHandler(OrientationChangeHandler handler) {
-    maybeSetupOrientation();
+	getOrientationHandler().maybeSetupOrientation(getManager());
     return getManager().addHandler(OrientationChangeEvent.getType(), handler);
   }
 
@@ -257,47 +268,10 @@ public class MGWT {
    * 
    * @return the current orientation of the device
    */
-  public static ORIENTATION getOrientation() {
-
-    if (!orientationSupport()) {
-      int height = Window.getClientHeight();
-      int width = Window.getClientWidth();
-
-      if (width > height) {
-        return ORIENTATION.LANDSCAPE;
-      } else {
-        return ORIENTATION.PORTRAIT;
-      }
-
-    } else {
-      int orientation = getOrientation0();
-
-      ORIENTATION o;
-      switch (orientation) {
-        case 0:
-        case 180:
-          o = ORIENTATION.PORTRAIT;
-          break;
-
-        case 90:
-        case -90:
-          o = ORIENTATION.LANDSCAPE;
-          break;
-
-        default:
-          throw new IllegalStateException("this should not happen!?");
-      }
-
-      return o;
-    }
-
+  public static ORIENTATION getOrientation(){
+	  return getOrientationHandler().getOrientation();
   }
-
-  private static void fireOrientationChangedEvent(ORIENTATION orientation) {
-    setClasses(orientation);
-    getManager().fireEvent(new OrientationChangeEvent(orientation));
-  }
-
+  
   private static Element getHead() {
     NodeList<Element> elementsByTagName = Document.get().getElementsByTagName("head");
 
@@ -307,121 +281,6 @@ public class MGWT {
 
     return elementsByTagName.getItem(0);
   }
-
-  private static native int getOrientation0()/*-{
-		if (typeof ($wnd.orientation) == 'undefined') {
-			return 0;
-		}
-
-		return $wnd.orientation;
-  }-*/;
-
-  private static void onorientationChange(int orientation) {
-
-    ORIENTATION o;
-    switch (orientation) {
-      case 0:
-      case 180:
-        o = ORIENTATION.PORTRAIT;
-        break;
-
-      case 90:
-      case -90:
-        o = ORIENTATION.LANDSCAPE;
-        break;
-
-      default:
-        o = ORIENTATION.PORTRAIT;
-        break;
-    }
-    currentOrientation = o;
-    fireOrientationChangedEvent(o);
-
-  }
-
-  // update styles on body
-  private static void setClasses(ORIENTATION o) {
-    UtilCss utilCss = MGWTStyle.getTheme().getMGWTClientBundle().getUtilCss();
-    switch (o) {
-
-      case PORTRAIT:
-        Document.get().getBody().addClassName(utilCss.portrait());
-        Document.get().getBody().removeClassName(utilCss.landscape());
-        break;
-      case LANDSCAPE:
-        Document.get().getBody().addClassName(utilCss.landscape());
-        Document.get().getBody().removeClassName(utilCss.portrait());
-        break;
-
-      default:
-        break;
-    }
-  }
-
-  private native static boolean orientationSupport()/*-{
-		var ua = window.navigator.userAgent.toLowerCase();
-		if (ua.indexOf('android') != -1) {
-			return false;
-		}
-		if (ua.indexOf('iphone') != -1) {
-			return true;
-		}
-		if (ua.indexOf('ipad') != -1) {
-			return true;
-		}
-
-		return false;
-  }-*/;
-
-  private static boolean orientationInitialized;
-
-  private static void maybeSetupOrientation() {
-    if (orientationInitialized)
-      return;
-    if (!GWT.isClient()) {
-      return;
-    }
-
-    if (!orientationSupport()) {
-      Window.addResizeHandler(new ResizeHandler() {
-
-        @Override
-        public void onResize(ResizeEvent event) {
-          ORIENTATION orientation = getOrientation();
-          if (orientation != currentOrientation) {
-            currentOrientation = orientation;
-            fireOrientationChangedEvent(orientation);
-          }
-        }
-      });
-    } else {
-      nativeJsFunction = setupOrientation0();
-      Window.addCloseHandler(new CloseHandler<Window>() {
-
-        @Override
-        public void onClose(CloseEvent<Window> event) {
-          destroyOrientation(nativeJsFunction);
-
-        }
-      });
-    }
-
-  }
-
-  private static native JavaScriptObject setupOrientation0()/*-{
-
-		var func = $entry(function() {
-			@com.googlecode.mgwt.ui.client.MGWT::onorientationChange(I)($wnd.orientation);
-		});
-		$doc.body.onorientationchange = func;
-		$doc.addEventListener("orientationChanged", func);
-		return func;
-  }-*/;
-
-  private static native void destroyOrientation(JavaScriptObject o)/*-{
-		$doc.body.onorientationchange = null;
-		$doc.removeEventListener("orientationChanged", o);
-  }-*/;
 
   private static native void setupPreventScrolling(Element el)/*-{
 		var func = function(event) {

--- a/src/main/java/com/googlecode/mgwt/ui/client/util/OrientationHandler.java
+++ b/src/main/java/com/googlecode/mgwt/ui/client/util/OrientationHandler.java
@@ -1,0 +1,12 @@
+package com.googlecode.mgwt.ui.client.util;
+
+import com.google.web.bindery.event.shared.EventBus;
+import com.googlecode.mgwt.dom.client.event.orientation.OrientationChangeEvent.ORIENTATION;
+
+public interface OrientationHandler {
+
+	public abstract ORIENTATION getOrientation();
+
+	void maybeSetupOrientation(EventBus manager);
+	
+}

--- a/src/main/java/com/googlecode/mgwt/ui/client/util/impl/BaseOrientationHandler.java
+++ b/src/main/java/com/googlecode/mgwt/ui/client/util/impl/BaseOrientationHandler.java
@@ -1,0 +1,144 @@
+package com.googlecode.mgwt.ui.client.util.impl;
+
+import com.google.gwt.core.client.GWT;
+import com.google.gwt.core.client.JavaScriptObject;
+import com.google.gwt.dom.client.Document;
+import com.google.gwt.event.logical.shared.CloseEvent;
+import com.google.gwt.event.logical.shared.CloseHandler;
+import com.google.gwt.user.client.Window;
+import com.google.web.bindery.event.shared.EventBus;
+import com.googlecode.mgwt.dom.client.event.orientation.OrientationChangeEvent;
+import com.googlecode.mgwt.dom.client.event.orientation.OrientationChangeEvent.ORIENTATION;
+import com.googlecode.mgwt.ui.client.MGWTStyle;
+import com.googlecode.mgwt.ui.client.theme.base.UtilCss;
+import com.googlecode.mgwt.ui.client.util.OrientationHandler;
+
+public abstract class BaseOrientationHandler implements OrientationHandler {
+	protected static ORIENTATION currentOrientation;
+	protected static boolean orientationInitialized;
+	private EventBus manager;
+
+	protected JavaScriptObject nativeJsFunction;
+
+	@Override
+	public final void maybeSetupOrientation(EventBus manager) {
+		this.manager = manager;
+		if (orientationInitialized)
+			return;
+		if (!GWT.isClient()) {
+			return;
+		}
+		doSetupOrientation();
+		orientationInitialized = true;
+	}
+	
+	protected abstract void doSetupOrientation();
+	
+	private void onorientationChange(int orientation) {
+
+		ORIENTATION o;
+		switch (orientation) {
+		case 0:
+		case 180:
+			o = ORIENTATION.PORTRAIT;
+			break;
+
+		case 90:
+		case -90:
+			o = ORIENTATION.LANDSCAPE;
+			break;
+
+		default:
+			o = ORIENTATION.PORTRAIT;
+			break;
+		}
+		currentOrientation = o;
+		fireOrientationChangedEvent(o);
+
+	}
+
+	void fireOrientationChangedEvent(ORIENTATION orientation) {
+		setClasses(orientation);
+		manager.fireEvent(new OrientationChangeEvent(orientation));
+	}
+
+	// update styles on body
+	private static void setClasses(ORIENTATION o) {
+		UtilCss utilCss = MGWTStyle.getTheme().getMGWTClientBundle()
+				.getUtilCss();
+		switch (o) {
+
+		case PORTRAIT:
+			Document.get().getBody().addClassName(utilCss.portrait());
+			Document.get().getBody().removeClassName(utilCss.landscape());
+			break;
+		case LANDSCAPE:
+			Document.get().getBody().addClassName(utilCss.landscape());
+			Document.get().getBody().removeClassName(utilCss.portrait());
+			break;
+
+		default:
+			break;
+		}
+	}
+
+	protected void setupNativeBrowerOrientationHandler() {
+		nativeJsFunction = setupOrientation0(this);
+		Window.addCloseHandler(new CloseHandler<Window>() {
+
+			@Override
+			public void onClose(CloseEvent<Window> event) {
+				destroyOrientation(nativeJsFunction);
+
+			}
+		});
+	}
+
+	private static native JavaScriptObject setupOrientation0(
+			BaseOrientationHandler handler)/*-{
+
+		var func = $entry(function() {
+			handler.@com.googlecode.mgwt.ui.client.util.impl.BaseOrientationHandler::onorientationChange(I)($wnd.orientation);
+		});
+		$doc.body.onorientationchange = func;
+		$doc.addEventListener("orientationChanged", func);
+		return func;
+	}-*/;
+
+	private static native void destroyOrientation(JavaScriptObject o)/*-{
+		$doc.body.onorientationchange = null;
+		$doc.removeEventListener("orientationChanged", o);
+	}-*/;
+
+
+	protected static native int getOrientation0()/*-{
+		if (typeof ($wnd.orientation) == 'undefined') {
+			return 0;
+		}
+
+		return $wnd.orientation;
+	}-*/;
+
+	protected static ORIENTATION getBrowserOrientation() {
+		int orientation = getOrientation0();
+	
+	      ORIENTATION o;
+	      switch (orientation) {
+	        case 0:
+	        case 180:
+	          o = ORIENTATION.PORTRAIT;
+	          break;
+	
+	        case 90:
+	        case -90:
+	          o = ORIENTATION.LANDSCAPE;
+	          break;
+	
+	        default:
+	          throw new IllegalStateException("this should not happen!?");
+	      }
+	
+	      return o;
+	}
+
+}

--- a/src/main/java/com/googlecode/mgwt/ui/client/util/impl/IOSOrientationHandler.java
+++ b/src/main/java/com/googlecode/mgwt/ui/client/util/impl/IOSOrientationHandler.java
@@ -1,0 +1,22 @@
+package com.googlecode.mgwt.ui.client.util.impl;
+
+import com.googlecode.mgwt.dom.client.event.orientation.OrientationChangeEvent.ORIENTATION;
+import com.googlecode.mgwt.ui.client.util.OrientationHandler;
+
+public class IOSOrientationHandler extends BaseOrientationHandler implements
+		OrientationHandler {
+
+	@Override
+	public void doSetupOrientation() {
+		setupNativeBrowerOrientationHandler();
+	}
+
+	@Override
+	public ORIENTATION getOrientation() {
+		return getBrowserOrientation();
+	}
+
+	
+
+	
+}

--- a/src/main/java/com/googlecode/mgwt/ui/client/util/impl/ResizeOrientationHandler.java
+++ b/src/main/java/com/googlecode/mgwt/ui/client/util/impl/ResizeOrientationHandler.java
@@ -1,0 +1,64 @@
+package com.googlecode.mgwt.ui.client.util.impl;
+
+import com.google.gwt.event.logical.shared.ResizeEvent;
+import com.google.gwt.event.logical.shared.ResizeHandler;
+import com.google.gwt.user.client.Window;
+import com.googlecode.mgwt.dom.client.event.orientation.OrientationChangeEvent.ORIENTATION;
+import com.googlecode.mgwt.ui.client.util.OrientationHandler;
+
+public class ResizeOrientationHandler extends BaseOrientationHandler implements
+		OrientationHandler {
+
+	@Override
+	public void doSetupOrientation() {
+
+		if (!orientationEventSupported()) {
+			Window.addResizeHandler(new ResizeHandler() {
+
+				@Override
+				public void onResize(ResizeEvent event) {
+					ORIENTATION orientation = getOrientation();
+					if (orientation != currentOrientation) {
+						currentOrientation = orientation;
+						fireOrientationChangedEvent(orientation);
+					}
+				}
+			});
+		} else {
+			setupNativeBrowerOrientationHandler();
+		}
+
+	}
+
+	private native static boolean orientationEventSupported()/*-{
+		return "onorientationchange" in $wnd;
+	}-*/;
+
+	/**
+	 * Get the current orientation of the device
+	 * 
+	 * @return the current orientation of the device
+	 */
+	public ORIENTATION getOrientation() {
+
+		if (!orientationSupport()) {
+			int height = Window.getClientHeight();
+			int width = Window.getClientWidth();
+
+			if (width > height) {
+				return ORIENTATION.LANDSCAPE;
+			} else {
+				return ORIENTATION.PORTRAIT;
+			}
+
+		} else {
+			return getBrowserOrientation();
+		}
+
+	}
+
+	private static native boolean orientationSupport() /*-{
+		return "orientation" in $wnd;
+	}-*/;
+
+}


### PR DESCRIPTION
Fixes ISSUE 307 where the Nav bar was showing on the nexus 7, 7 inch
tablet in Portrait mode whenever the virtual keyboard was shown. 
The code changes also fixed another issue where the
orientationInitialized variable was never initialized to true causing
the initialization to be repeated everytime a handler was added. 

This code refactored the orientation handler into different files
initalized by GWT.create. This will enable other developers to implement
their own OrientationHandler if there is a bug in the current code.
